### PR TITLE
Flip contract - intial

### DIFF
--- a/backend/contracts/Flip.sol
+++ b/backend/contracts/Flip.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity >=0.7.0 <0.9.0;
+
+contract Flip {
+
+    bool private randomise;
+    uint256 private flipCount;  
+    address tokenAddress;
+
+    // flipstate mapping (0 == new address, 1 == odd flips, 2 == even flips).
+    mapping(address => uint8) private flipstate;
+
+    uint256 private addresscount; 
+
+    // Log successful flips
+    event flip(address, uint8); 
+
+        constructor(bool _rand, address _token) {
+        
+        randomise = _rand; // true or false depending on if randomise is required
+        tokenAddress = _token; // ERC20 token to use as prize. 0 if prize is in ETH
+    }
+
+    // flipCoin() uses a flip strategy to determine whether to send a prize or not.
+    // There are 2 strategies: alternating flips and randmomised flips.
+    function flipCoin() public {
+        require(address(this).balance >= 1 ether, "Fund too low");
+
+        // switch on type of flip
+        if (randomise == true){
+            flipRandom(); // Use randomised flips
+        } else {
+            flipAlternate(); // Use alternating flips
+        }
+
+        flipCount++; //count every flip
+
+    }
+
+    // flipAlternate() changes the flip the state for each address between 1 and 2
+    // Releases .01 ETH on every second flip
+    function flipAlternate() private {
+        // Check for second flip
+        if (flipstate[msg.sender] == 2) {
+            sendPrize();
+        }
+
+        // Log the flip
+        emit flip(msg.sender, flipstate[msg.sender]);
+
+        // Update the flip state
+        if (++flipstate[msg.sender] == 3){
+            flipstate[msg.sender] = 1; // Flip back to 1
+        } 
+
+        // Check new address
+        if (flipstate[msg.sender] == 0) {
+            addresscount++;
+        }
+    }
+
+    // flipRandom() generates a best-effort front-run resistant random number.
+    // Sends a prise if it is even.  
+    function flipRandom() private {
+      
+        if (uint(keccak256(abi.encodePacked(msg.sender, flipCount, blockhash(block.number),block.gaslimit, block.prevrandao, block.timestamp))) % 2 == 0){
+            sendPrize();
+        }
+    }
+
+    function sendPrize() private {
+        require (tokenAddress ==address(0),"ERC20 Tokens not supported yet");
+        //Send 0.01 ETH using the ugly but safe method.
+        (bool sent, bytes memory data) = msg.sender.call{
+           value: 10000000000000000
+        }("");
+        require(sent, "Failed to send Ether");
+    }
+
+    // Get the current flip state for a given address
+    function getFlipCount(address _addr) public view returns (uint256) {
+        return flipstate[_addr];
+    }
+}

--- a/backend/contracts/Flip.sol
+++ b/backend/contracts/Flip.sol
@@ -14,7 +14,7 @@ contract Flip {
     uint256 private addresscount; 
 
     // Log successful flips
-    event flip(address, uint8); 
+    event flip(address, bool); 
 
         constructor(bool _rand, address _token) {
         
@@ -47,7 +47,7 @@ contract Flip {
         }
 
         // Log the flip
-        emit flip(msg.sender, flipstate[msg.sender]);
+        emit flip(msg.sender, flipstate[msg.sender]==2);
 
         // Update the flip state
         if (++flipstate[msg.sender] == 3){
@@ -63,10 +63,16 @@ contract Flip {
     // flipRandom() generates a best-effort front-run resistant random number.
     // Sends a prise if it is even.  
     function flipRandom() private {
+
+        // Generate random number
+        uint rand = uint(keccak256(abi.encodePacked(msg.sender, flipCount, blockhash(block.number),block.gaslimit, block.prevrandao, block.timestamp)));
+
+        bool win = (rand % 2 == 0); // The user has won if the hash is even
       
-        if (uint(keccak256(abi.encodePacked(msg.sender, flipCount, blockhash(block.number),block.gaslimit, block.prevrandao, block.timestamp))) % 2 == 0){
-            sendPrize();
-        }
+        if (win) { sendPrize();}
+    
+        // Log the flip
+        emit flip(msg.sender, win);
     }
 
     function sendPrize() private {

--- a/backend/contracts/Flip.sol
+++ b/backend/contracts/Flip.sol
@@ -25,7 +25,6 @@ contract Flip {
     // flipCoin() uses a flip strategy to determine whether to send a prize or not.
     // There are 2 strategies: alternating flips and randmomised flips.
     function flipCoin() public {
-        require(address(this).balance >= 1 ether, "Fund too low");
 
         // switch on type of flip
         if (randomise == true){
@@ -77,6 +76,7 @@ contract Flip {
 
     function sendPrize() private {
         require (tokenAddress ==address(0),"ERC20 Tokens not supported yet");
+        require(address(this).balance >= 1 ether, "Insufficient funds");
         //Send 0.01 ETH using the ugly but safe method.
         (bool sent, bytes memory data) = msg.sender.call{
            value: 10000000000000000

--- a/backend/contracts/Flip.sol
+++ b/backend/contracts/Flip.sol
@@ -6,7 +6,7 @@ contract Flip {
 
     bool private randomise;
     uint256 private flipCount;  
-    address tokenAddress;
+    address private tokenAddress;
 
     // flipstate mapping (0 == new address, 1 == odd flips, 2 == even flips).
     mapping(address => uint8) private flipstate;
@@ -85,7 +85,11 @@ contract Flip {
     }
 
     // Get the current flip state for a given address
-    function getFlipCount(address _addr) public view returns (uint256) {
+    function getFlipState(address _addr) public view returns (uint256) {
         return flipstate[_addr];
+    }
+
+    function getInternalState() public view returns (bool, address, uint256, uint256 ){
+        return(randomise, tokenAddress, flipCount, addresscount);
     }
 }

--- a/backend/contracts/FlipRandom.sol
+++ b/backend/contracts/FlipRandom.sol
@@ -12,15 +12,15 @@ The prize is 0.01 ETH and the contract balance cannot fall below 1 ETH.
 contract FlipRandom {
     // Event to log whether a flip has resulted in a prize
     event flip(address, bool); 
-        constructor() {
+        constructor() payable {
     }
 
     // flipCoin() generates a best-effort front-run resistant random number.
     // Sends a prise if it is even.  
-    function flipCoin() private returns (bool){
+    function flipCoin() public returns (bool){
         require(address(this).balance >= 1 ether, "Fund too low");
         // Generate a random number
-        uint rand = uint(keccak256(abi.encodePacked(msg.sender, blockhash(block.number),block.gaslimit, block.prevrandao, block.timestamp)));
+        uint rand = uint(keccak256(abi.encodePacked(msg.sender, blockhash(block.number),msg.sender.balance, block.prevrandao, block.timestamp)));
         bool win = (rand % 2 == 0); // The user has won if the random number is even
         if (win) { 
             sendPrize();

--- a/backend/contracts/FlipRandom.sol
+++ b/backend/contracts/FlipRandom.sol
@@ -6,7 +6,7 @@ pragma solidity >=0.7.0 <0.9.0;
                          A TRIVIAL RANDOM COIN FLIP CONTRACT
 This contract has a single function that flips a coin and sends the prize depending on a random number.
 The random number is generated using a hash of several highly unpredictable valaues to minimise front-running.
-The prize is 0.01 ETH and the contract balabce cannot fall below 1 ETH. 
+The prize is 0.01 ETH and the contract balance cannot fall below 1 ETH. 
 */
 
 contract FlipRandom {
@@ -17,15 +17,16 @@ contract FlipRandom {
 
     // flipCoin() generates a best-effort front-run resistant random number.
     // Sends a prise if it is even.  
-    function flipCoin() private {
+    function flipCoin() private returns (bool){
         require(address(this).balance >= 1 ether, "Fund too low");
         // Generate a random number
         uint rand = uint(keccak256(abi.encodePacked(msg.sender, blockhash(block.number),block.gaslimit, block.prevrandao, block.timestamp)));
         bool win = (rand % 2 == 0); // The user has won if the random number is even
         if (win) { 
             sendPrize();
-        }
+         } 
         emit flip(msg.sender, win); // Log the flip
+        return (win); 
     }
 
     function sendPrize() private {

--- a/backend/contracts/FlipRandom.sol
+++ b/backend/contracts/FlipRandom.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity >=0.7.0 <0.9.0;
+
+/*
+                         A TRIVIAL RANDOM COIN FLIP CONTRACT
+This contract has a single function that flips a coin and sends the prize depending on a random number.
+The random number is generated using a hash of several highly unpredictable valaues to minimise front-running.
+The prize is 0.01 ETH and the contract balabce cannot fall below 1 ETH. 
+*/
+
+contract FlipRandom {
+    // Event to log whether a flip has resulted in a prize
+    event flip(address, bool); 
+        constructor() {
+    }
+
+    // flipCoin() generates a best-effort front-run resistant random number.
+    // Sends a prise if it is even.  
+    function flipCoin() private {
+        require(address(this).balance >= 1 ether, "Fund too low");
+        // Generate a random number
+        uint rand = uint(keccak256(abi.encodePacked(msg.sender, blockhash(block.number),block.gaslimit, block.prevrandao, block.timestamp)));
+        bool win = (rand % 2 == 0); // The user has won if the random number is even
+        if (win) { 
+            sendPrize();
+        }
+        emit flip(msg.sender, win); // Log the flip
+    }
+
+    function sendPrize() private {
+        require(address(this).balance >= 1 ether, "Fund too low");
+        //Send 0.01 ETH using the ugly but safe method.
+        (bool sent, bytes memory data) = msg.sender.call{
+           value: 10000000000000000
+        }("");
+        require(sent, "Failed to send Ether");
+    }
+}


### PR DESCRIPTION
A contract that flips a coin and sends the caller 0.01 ETH if it lands on 'heads'.

To use: 

1. Deploy contract 'FlipRandom' from a deployment account and pass in at least 2 ETH (will not allow balance to go below 1 ETH).
2. Call the flipCoin() function from another account.
3. Check result and emitted log.
4. If the result is true, then check the balance of the calling account has been incremented by ~0.01 ETH 
5. If false, then check that the balance of the calling account has not changed (remember some gas will have been used)