### PR TITLE
Create FlipRandom.sol

### DIFF
--- a/backend/contracts/FlipRandom.sol
+++ b/backend/contracts/FlipRandom.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity >=0.7.0 <0.9.0;
+
+/*
+                         A TRIVIAL RANDOM COIN FLIP CONTRACT
+This contract has a single function that flips a coin and sends the prize depending on a random number.
+The random number is generated using a hash of several highly unpredictable valaues to minimise front-running.
+The prize is 0.01 ETH and the contract balance cannot fall below 1 ETH. 
+*/
+
+contract FlipRandom {
+    // Event to log whether a flip has resulted in a prize
+    event flip(address, bool); 
+        constructor() payable {
+    }
+
+    // flipCoin() generates a best-effort front-run resistant random number.
+    // Sends a prise if it is even.  
+    function flipCoin() public returns (bool){
+        require(address(this).balance >= 1 ether, "Fund too low");
+        // Generate a random number
+        uint rand = uint(keccak256(abi.encodePacked(msg.sender, blockhash(block.number),msg.sender.balance, block.prevrandao, block.timestamp)));
+        bool win = (rand % 2 == 0); // The user has won if the random number is even
+        if (win) { 
+            sendPrize();
+         } 
+        emit flip(msg.sender, win); // Log the flip
+        return (win); 
+    }
+
+    function sendPrize() private {
+        require(address(this).balance >= 1 ether, "Fund too low");
+        //Send 0.01 ETH using the ugly but safe method.
+        (bool sent, bytes memory data) = msg.sender.call{
+           value: 10000000000000000
+        }("");
+        require(sent, "Failed to send Ether");
+    }
+}


### PR DESCRIPTION
FilpRandom.sol is a contract that implements a trustless coin flip that returns 0.01 when the result is heads.

The contract must be deployed onchain with at least 1.5 ETH.  It will not allow the balance to fall below 1 ETH.

The Coin Flip dApp needs to call flipCoin():
1. A random number is generated using a hash function with sufficient entropy that it should be hard to front-run.
2. If the random number is even, 0.01 ETH is sent to the calling account.
3. The function returns true if a prize has been sent.
4. An event is logged with a boolean representing whether the prize was sent or not.